### PR TITLE
Multiple rooms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ APP_URL=http://localhost
 
 GOOGLE_CALENDAR_ID=
 
+# Rooms used by the application
+ROOM_ID_1=room_id_sample_1@justdigital.com.br
+ROOM_NAME_1="Sample Room 1"
+
+ROOM_ID_2=room_id_sample_2@justdigital.com.br
+ROOM_NAME_2="Sample Room 2"
+
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306

--- a/app/Services/RoomManager.php
+++ b/app/Services/RoomManager.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ConferenceRoomStatus\Services;
+
+class RoomManager {
+
+    /**
+     * @var array $rooms
+     */
+    protected $rooms;
+
+    /**
+     * RoomManager constructor
+     * 
+     * @return void
+     */
+    public function __construct() {
+        $roomVariables = array_filter($_ENV, function($key) {
+            return starts_with($key, 'ROOM_');
+        }, ARRAY_FILTER_USE_KEY);
+        
+        $this->loadRoomArray($roomVariables);
+    }
+
+    /**
+     * Loads the $rooms variable. Turns a sequence of strings into
+     * correlated arrays using the env var index (E.g.: _1).
+     * 
+     * @return void
+     */
+    private function loadRoomArray(array $roomVariables) {
+        foreach ($roomVariables as $key => $roomVar) {
+            $xplodedKey = explode('_', $key);
+            $identifier = end($xplodedKey);
+            if (str_contains($key, 'NAME')) {
+                $this->rooms[$identifier]['NAME'] = $roomVar;
+            }
+            if (str_contains($key, 'ID')) {
+                $this->rooms[$identifier]['ID'] = $roomVar;
+            }
+        }
+        $this->rooms = array_values($this->rooms);
+    }
+
+    /**
+     * Get all loaded rooms
+     * 
+     * @return array
+     */
+    public function all() : array {
+        return $this->rooms;
+    }
+
+    /**
+     * Get a Room ID By it's name
+     * 
+     * @param string $roomName
+     * 
+     * @return string
+     */
+    public function getByName(string $roomName) : string {
+        foreach ($this->rooms as $room) {
+            if ($room['NAME'] == $roomName) {
+                return $room['ID'];
+            }
+        }
+    }
+}

--- a/tests/Unit/GoogleCalendarServiceTest.php
+++ b/tests/Unit/GoogleCalendarServiceTest.php
@@ -10,7 +10,7 @@ class GoogleCalendarServiceTest extends TestCase
 {
 
     /**
-     * 
+     * @var ConferenceRoomStatus\Services\GoogleCalendar $calendarService
      */
     protected $calendarService;
 

--- a/tests/Unit/RoomManagerTest.php
+++ b/tests/Unit/RoomManagerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class RoomManagerTest extends TestCase
+{
+
+    /**
+     * @var ConferenceRoomStatus\Services\RoomManager $roomManagerService
+     */
+    protected $roomManagerService;
+
+    /**
+     * TestCase setUp
+     */
+    public function setUp() {
+        parent::setUp();
+        $this->roomManagerService = $this->app->make('\ConferenceRoomStatus\Services\RoomManager');
+    }
+
+    /**
+     * Tests if the Manager can be created
+     */
+    public function testCanGetRoomManager() {
+        $this->assertInstanceOf('\ConferenceRoomStatus\Services\RoomManager', $this->roomManagerService);
+    }
+
+    /**
+     * Test if the Manager can load all rooms
+     *
+     * @return void
+     */
+    public function testCanGetAllRooms() {
+        $expected = [
+            [
+                'ID' => 'room_id_sample_1@justdigital.com.br',
+                'NAME' => 'Sample Room 1'
+            ],
+            [
+                'ID' => 'room_id_sample_2@justdigital.com.br',
+                'NAME' => 'Sample Room 2'
+            ]
+        ];
+
+        $rooms = $this->roomManagerService->all();
+        
+        $this->assertTrue(is_array($rooms));
+        $this->assertEquals($expected[0]['ID'], $rooms[0]['ID']);
+        $this->assertEquals($expected[0]['NAME'], $rooms[0]['NAME']);
+        $this->assertEquals($expected[1]['ID'], $rooms[1]['ID']);
+        $this->assertEquals($expected[1]['NAME'], $rooms[1]['NAME']);
+    }
+
+    /**
+     * Test if the Manager can get a ID By a Room's name
+     * 
+     * @return void
+     */
+    public function testCanGetByName() {
+        $expectedRoomId = "room_id_sample_1@justdigital.com.br";
+        $roomName = "Sample Room 1";
+
+        $roomId = $this->roomManagerService->getByName($roomName);
+
+        $this->assertEquals($expectedRoomId, $roomId);
+    }
+}


### PR DESCRIPTION
Now we can use the RoomManager class to load all Rooms available on the .env file, since it's following the name convention like the .env sample file.

E.g.:
```
ROOM_ID_1=
ROOM_NAME_1=

ROOM_ID_2=
ROOM_NAME_2=
```

Usage:
```php
use ConferenceRoomStatus\Services\RoomManager;

...

$roomManager = new RoomManager(); // Dependendy Injection is preferred
$allRooms = $roomManager->all();
```